### PR TITLE
fixed issue for floating position when window is resized

### DIFF
--- a/jquery.floatingFixed.js
+++ b/jquery.floatingFixed.js
@@ -74,5 +74,13 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     }
   };
 
-  $window.scroll(windowScroll).resize(windowScroll);
+  $window.scroll(windowScroll);//.resize(windowScroll);
+  $window.resize(function(){
+      if(triggers.length === 0) { return; }
+      for(var i = 0; i < triggers.length; i++) {
+         var floater = triggers[i];
+         if(floater.data("isFloating"))
+           floater.css({left: floater.parent().offset().left + floater.data("floatingFixedOrig").left});
+      }
+  });
 })(jQuery);


### PR DESCRIPTION
Hi I have fixed the issue of left position while it is scrolled down and window is resized. You can test and merge the change in master. I have tested in ff-10.0.2 and chrome-17.0.963.56.
